### PR TITLE
Include subdirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ setup(
     keywords='open_buildings',
     name='open-buildings',
     packages=find_packages(),
+    package_data={
+        'open_buildings': ['google/*', 'overture/*' ],
+    },
     setup_requires=setup_requirements,
     test_suite='tests',
     tests_require=test_requirements,


### PR DESCRIPTION
google and overture subdirectories are not being included in the final package

This change helps setup.py include them but should not be necessary given that we are using `find_packages`.

Submitting the PR since it technically works until a better solution is found.