### PR TITLE
35 - Don't create empty files if there are 0 features

### DIFF
--- a/open_buildings/download_buildings.py
+++ b/open_buildings/download_buildings.py
@@ -223,6 +223,8 @@ def download(geojson_input, format, generate_sql, dst, silent, overwrite, verbos
 
         print_timestamped_message(f"Downloaded {count} features into DuckDB.")
         if count == 0:
+            if country_iso is not None:
+                print_timestamped_message(f"If you are sure that your GeoJSON should have buildings then check to be sure that {country_iso} is the right code.")
             if verbose:
                 print_elapsed_time(start_time)
             return

--- a/open_buildings/download_buildings.py
+++ b/open_buildings/download_buildings.py
@@ -137,6 +137,12 @@ def download(geojson_input, format, generate_sql, dst, silent, overwrite, verbos
             current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             click.echo(f"[{current_time}] {message}")
 
+    def print_elapsed_time(start_time):
+        end_time = time.time()
+
+        elapsed_time = end_time - start_time
+        print_timestamped_message(f"Operation took {elapsed_time:.2f} seconds.")
+
     start_time = time.time()
     if verbose:
         print_timestamped_message("Reading GeoJSON input...")
@@ -216,6 +222,10 @@ def download(geojson_input, format, generate_sql, dst, silent, overwrite, verbos
         count = conn.execute("SELECT COUNT(*) FROM buildings;").fetchone()[0]
 
         print_timestamped_message(f"Downloaded {count} features into DuckDB.")
+        if count == 0:
+            if verbose:
+                print_elapsed_time(start_time)
+            return
     if not generate_sql:
         print_timestamped_message(f"Writing to {dst}...")
 
@@ -251,12 +261,9 @@ def download(geojson_input, format, generate_sql, dst, silent, overwrite, verbos
             'flatgeobuf': 'FlatGeobuf'
         }
         conn.execute(f"COPY buildings TO '{dst}' WITH (FORMAT GDAL, DRIVER '{gdal_format[format]}');")
-    end_time = time.time()
-
+          
     if verbose:
-        elapsed_time = end_time - start_time
-        print_timestamped_message(f"Operation took {elapsed_time:.2f} seconds.")      
-
+        print_elapsed_time(start_time)
 
 # Registering the commands with the main group
 cli.add_command(quadkey)


### PR DESCRIPTION
Resolves #35 

This PR makes it so a result file is not created if the query returns zero features.

I assumed if the `verbose` option was used, it should print the elapsed time (broke out into new function).