### PR TITLE
install spatial extension if not installed

### DIFF
--- a/open_buildings/download_buildings.py
+++ b/open_buildings/download_buildings.py
@@ -216,12 +216,12 @@ def download(geojson_input, format, generate_sql, dst, silent, overwrite, verbos
         print_timestamped_message(create_clause)
     if not generate_sql:
         conn = duckdb.connect(database=':memory:')
-        try:
-            conn.execute("load spatial;")
-        except duckdb.duckdb.IOException:
+
+        spatial_extension_query = conn.execute("SELECT * FROM duckdb_extensions() WHERE installed IS TRUE AND extension_name = 'spatial';").fetchone()
+        if spatial_extension_query is None:
             print_timestamped_message("Installing DuckDB spatial extension...")
-            conn.execute("install spatial;")
-            conn.execute("load spatial;")
+            conn.execute("INSTALL spatial;")
+        conn.execute("LOAD spatial;")
         conn.execute(create_clause)
 
         count = conn.execute("SELECT COUNT(*) FROM buildings;").fetchone()[0]

--- a/open_buildings/download_buildings.py
+++ b/open_buildings/download_buildings.py
@@ -216,7 +216,12 @@ def download(geojson_input, format, generate_sql, dst, silent, overwrite, verbos
         print_timestamped_message(create_clause)
     if not generate_sql:
         conn = duckdb.connect(database=':memory:')
-        conn.execute("load spatial;")
+        try:
+            conn.execute("load spatial;")
+        except duckdb.duckdb.IOException:
+            print_timestamped_message("Installing DuckDB spatial extension...")
+            conn.execute("install spatial;")
+            conn.execute("load spatial;")
         conn.execute(create_clause)
 
         count = conn.execute("SELECT COUNT(*) FROM buildings;").fetchone()[0]


### PR DESCRIPTION
Resolves #38 

In this PR, we attempt to load the `spatial` duckdb extension. If it fails to load because it has not been installed, install it, then load the extension.