### PR TITLE
Some performance quick wins for the geopandas implementation

### DIFF
--- a/open_buildings/google/process.py
+++ b/open_buildings/google/process.py
@@ -210,14 +210,13 @@ def process_with_pandas(
     input_file_path, split_multipolygons, verbose, format, output_file_path
 ):
     df = pd.read_csv(input_file_path)
-    df['geometry'] = df['geometry'].apply(wkt.loads)
+    gs = gpd.GeoSeries.from_wkt(df['geometry'])
 
-    # Drop the 'latitude' and 'longitude' columns
-    df = df.drop(['latitude', 'longitude'], axis=1)
+    # Drop the 'latitude', 'longitude' and 'geometry' columns
+    df = df.drop(['latitude', 'longitude', 'geometry'], axis=1)
 
     # Convert the DataFrame to a GeoDataFrame
-    gdf = gpd.GeoDataFrame(df, geometry='geometry')
-    gdf.set_crs("EPSG:4326", inplace=True)
+    gdf = gpd.GeoDataFrame(df, geometry=gs, crs="EPSG:4326")
 
     # Create an empty GeoDataFrame for the output
     output_gdf = gpd.GeoDataFrame(columns=list(gdf.columns), crs=gdf.crs)
@@ -295,11 +294,13 @@ def process_with_pandas(
         )
     # Write the output GeoDataFrame to a file
     if format == 'fgb':
-        output_gdf.to_file(output_file_path, driver="FlatGeobuf")
+        output_gdf.to_file(output_file_path, driver="FlatGeobuf", engine="pyogrio")
     elif format == 'parquet':
         output_gdf.to_parquet(output_file_path, compression=PARQUET_COMPRESSION)
     elif format == 'gpkg':
-        output_gdf.to_file(output_file_path, driver='GPKG')
+        output_gdf.to_file(
+            output_file_path, driver='GPKG', engine="pyogrio", spatial_index=False
+        )
     elif format == 'shp':
         output_gdf.to_file(output_file_path, driver='ESRI Shapefile')
 

--- a/open_buildings/google/process.py
+++ b/open_buildings/google/process.py
@@ -302,7 +302,7 @@ def process_with_pandas(
             output_file_path, driver='GPKG', engine="pyogrio", spatial_index=False
         )
     elif format == 'shp':
-        output_gdf.to_file(output_file_path, driver='ESRI Shapefile')
+        output_gdf.to_file(output_file_path, driver='ESRI Shapefile', engine="pyogrio")
 
 
 def process_with_ogr2ogr(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click
 duckdb
 pandas
 geopandas
+pyogrio
 shapely
 openlocationcode
 tabulate


### PR DESCRIPTION
I encountered a link to your [blog post](https://cloudnativegeo.org/blog/2023/08/performance-explorations-of-geoparquet-and-duckdb/) with some performance comparisons between file formats. Because the performance differences there were not quite what I expected I got curious and had a look at the code.

This PR should give a boost to the performance of .fgb, .gpkg and .shp. I disabled creation of the spatial index on .gpkg because all other formats also don't have a spatial index and creating the spatial index takes quite some time. If you want to do serious spatial analyses using sql on the .gpkg file the spatial index can obviously be a huge advantage, but I don't think this is the case.